### PR TITLE
fix: Make Flatpak TeX Live more clear

### DIFF
--- a/docs/en/getting-started/installing-latex.md
+++ b/docs/en/getting-started/installing-latex.md
@@ -26,7 +26,7 @@ Similar to Windows, macOS also features simple installers that will install one 
 
 ## Linux
 
-Linux distributions commonly have several LaTeX packages available to install directly from your software manager. There are also minimal and full packages. We list options for common distributions below.
+Linux distributions commonly have several LaTeX packages available to install directly from your software manager. If you're running the Flatpak version, you must install the Flatpak TeX Live extension, rather than a TeX distribution from your system software manager. There are also minimal and full packages. We list options for common distributions below.
 
 !!! note
 


### PR DESCRIPTION
The current docs seems to suggest that if you're running the Flatpak version you can either install a TeX distribution system wide or through the TeX Live Flatpak extension. This isn't the case due to Flatpak sandboxing.

This PR intends to add a bit of context, and make it clear what you need to install to get TeX working.

Thanks for the review.